### PR TITLE
changed the config for Jest. no longer have to stop server to run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "react-dev": "webpack --watch",
-    "server-dev": "nodemon server/index.js",
+    "server-dev": "nodemon server/server.js",
     "seed": "node helpers/index.js",
-    "test-jest": "jest --watchAll --config=jestconfig.json"
+    "test-jest": "jest --watchAll --detectOpenHandles --runInBand --config=jestconfig.json"
   },
   "repository": {
     "type": "git",

--- a/server/index.js
+++ b/server/index.js
@@ -14,14 +14,8 @@ app.get('/api/locations', (req, res) => {
   }
   db.getOneProdLoc(productID)
     .then(data => res.send(data))
-    .catch(error => console.log(error))
+    .catch(error => res.sendState(404))
     //if error send status code of  404
 })
-
-let port = 6002
-
-app.listen(port, function () {
-    console.log(`listening on port ${port}`);
-});
 
 module.exports = app

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,9 +1,9 @@
-const request = require('supertest');
 const app = require('./index.js');
+const supertest = require('supertest');
+const request = supertest(app);
 
 test('get locations api test', async () => {
-  await request(app)
-    .get('/api/locations?product_id=1')
+  await request.get('/api/locations?product_id=1')
     .expect(200)
     .then(response => {
       expect(typeof response).toBe('object');
@@ -12,7 +12,6 @@ test('get locations api test', async () => {
 
 
 test('get locations for product not in database', async () => {
-  await request(app)
-    .get('/api/locations?product_id=101')
+  await request.get('/api/locations?product_id=101')
     .expect(404)
 });

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,9 @@
+const app = require('./index.js');
+
+// console.log(app);
+
+let port = 6002
+
+app.listen(port, function () {
+    console.log(`listening on port ${port}`);
+});


### PR DESCRIPTION
@masoncpott Hi Mason, can you please review this please?
I changed the config for Jest after doing some research. I no longer have to manually stop the server to run my test. I basically took the app.listen() out of the index.js file and created a new server.js file and added it there. This also eliminates my problem of :6002 port being already in use.